### PR TITLE
switch projects to be color-coded as functions

### DIFF
--- a/TodoTxt.tmLanguage
+++ b/TodoTxt.tmLanguage
@@ -33,7 +33,7 @@
 			<key>match</key>
 			<string>\+\S*</string>
 			<key>name</key>
-			<string>entity.name.tag.todotxt.project</string>
+			<string>entity.name.function.todotxt.project</string>
 		</dict>
 		<dict>
 			<key>comment</key>


### PR DESCRIPTION
Minor change so "+projects" and "@contexts" end up as different colors in most of the built-in color schemes. 