### PR TITLE
Add whitespace precursor to project and context

### DIFF
--- a/TodoTxt.tmLanguage
+++ b/TodoTxt.tmLanguage
@@ -23,7 +23,7 @@
 			<key>comment</key>
 			<string>Todo item context</string>
 			<key>match</key>
-			<string>\@\S*</string>
+			<string>\s\@\S*</string>
 			<key>name</key>
 			<string>entity.name.tag.todotxt.context</string>
 		</dict>
@@ -31,7 +31,7 @@
 			<key>comment</key>
 			<string>Todo item project</string>
 			<key>match</key>
-			<string>\+\S*</string>
+			<string>\s\+\S*</string>
 			<key>name</key>
 			<string>entity.name.function.todotxt.project</string>
 		</dict>


### PR DESCRIPTION
Allow for urls and email addresses to be added to todo.txt without triggering the project and context formatting