### PR TITLE
Fix highlighting of contexts and projects at beginning of done.txt

### DIFF
--- a/TodoTxt.sublime-syntax
+++ b/TodoTxt.sublime-syntax
@@ -51,12 +51,12 @@ contexts:
 
 
   inside_task:
-    - match: (?:\s|^)(\@\S+)
+    - match: (?:\s|^|\G)(\@\S+)
       comment: Todo item context
       captures:
         1: entity.name.tag.todotxt.context
 
-    - match: (?:\s|^)(\+\S+)
+    - match: (?:\s|^|\G)(\+\S+)
       comment: Todo item project
       captures:
         1: string.quoted.double.todotxt.project


### PR DESCRIPTION
If you try to run the current regular expressions on a done.txt file like `x 2022-11-08 +todo.txt syntax support for +bat
` then `+bat` will be highlighted but `+todo.txt` won't be. This commit fixes this.